### PR TITLE
scripts/os2dot: fix variables

### DIFF
--- a/scripts/os2dot
+++ b/scripts/os2dot
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 # this scripts transforms a moise specification (and .xml file) into
-# a .dot file and then into .svg, pdf, ....
+# a .dot file and then into .svg, .pdf, ...
 
-source `dirname $0`/jacamo-setup
+source `find $JACAMO_HOME/ -name jacamo-setup`
 
 MOISE_JAR=`find $JACAMO_HOME/libs  -name moise*.jar`
 NPL_JAR=`find $JACAMO_HOME/libs  -name npl*.jar`
 CARTAGO_JAR=`find $JACAMO_HOME/libs  -name cartago*.jar`
-C4JASON_JAR=`find $JACAMO_HOME/libs  -name jaca*.jar`
+C4JASON_JAR=`find $JACAMO_HOME/libs  -name jaca-*.jar`
 
 java -cp $MOISE_JAR:$JASON_JAR:$NPL_JAR:$CARTAGO_JAR:$C4JASON_JAR moise.tools.os2dot $*


### PR DESCRIPTION
Fixes to `jacamo-setup` and `jaca` variables.

The first has been changed to match the absolute path, while the `find` command in the second has been adjusted to exactly match JaCa (and not mistakenly JaCaMo).