### PR TITLE
Support to launch other jcm files on running time

### DIFF
--- a/src/main/java/jacamo/infra/JaCaMoLauncher.java
+++ b/src/main/java/jacamo/infra/JaCaMoLauncher.java
@@ -51,6 +51,10 @@ public class JaCaMoLauncher extends RunCentralisedMAS {
 
     protected List<Platform> platforms = new ArrayList<>();
 
+    public List<Platform> getPlatforms() {
+        return platforms;
+    }
+
     public static String defaultProjectFileName = "default.jcm";
 
     public static void main(String[] args) throws JasonException {

--- a/src/main/java/jacamo/platform/Cartago.java
+++ b/src/main/java/jacamo/platform/Cartago.java
@@ -1,5 +1,7 @@
 package jacamo.platform;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -10,6 +12,7 @@ import cartago.CartagoException;
 import cartago.CartagoService;
 import cartago.Op;
 import cartago.WorkspaceId;
+import cartago.WorkspaceKernel;
 import jaca.CartagoEnvironment;
 import jacamo.project.JaCaMoInstParameters;
 import jacamo.project.JaCaMoWorkspaceParameters;
@@ -17,8 +20,8 @@ import jason.mas2j.ClassParameters;
 
 public class Cartago extends DefaultPlatformImpl {
     
-    protected CartagoEnvironment  env;
-    protected CartagoContext      cartagoCtx;
+    protected CartagoEnvironment        env;
+    protected CartagoContext            cartagoCtx;
 
     Logger logger = Logger.getLogger(Cartago.class.getName());
 
@@ -31,36 +34,64 @@ public class Cartago extends DefaultPlatformImpl {
     
     @Override
     public void start() {
-        for (JaCaMoWorkspaceParameters wp: project.getWorkspaces()) {
+        for (JaCaMoWorkspaceParameters wp : project.getWorkspaces()) {
             try {
                 if (project.isInDeployment(wp.getNode())) {
-                    CartagoService.createWorkspace(wp.getName());
-                    logger.info("Workspace "+wp.getName()+" created.");
-                    EnvironmentWebInspector.get().registerWorkspace(wp.getName());
 
-                    WorkspaceId wid = cartagoCtx.joinWorkspace(wp.getName(), new AgentIdCredential("JaCaMoLauncherAgEnv"));
+                    if (!CartagoService.getNode().getWorkspaces().contains(wp.getName())) {
+                        CartagoService.createWorkspace(wp.getName());
+                        logger.info("Workspace " + wp.getName() + " created.");
+                        EnvironmentWebInspector.get().registerWorkspace(wp.getName());
+                    } else {
+                        logger.info("Workspace " + wp.getName() + " already exists.");
+                    }
+
+                    logger.info("getJoinedWorkspaces: " + cartagoCtx.getJoinedWorkspaces());
+                    WorkspaceId wid = null;
+
+                    WorkspaceKernel kernel = CartagoService.getNode().getWorkspace(wp.getName()).getKernel();
+                    List<String> ids = new ArrayList<>();
+                    for (ArtifactId aid : kernel.getArtifactIdList())
+                        ids.add(aid.getName());
+
+                    // getCurrentAgentContexts()
+                    for (WorkspaceId w : cartagoCtx.getJoinedWorkspaces()) {
+                        if (w.getName().equals(wp.getName())) {
+                            wid = cartagoCtx.getJoinedWspId(wp.getName());
+                        }
+                    }
+                    if (wid == null)
+                        wid = cartagoCtx.joinWorkspace(wp.getName(), new AgentIdCredential("JaCaMoLauncherAgEnv"));
+
                     wp.setWId(wid);
-                    
+
                     // check institution
-                    for (JaCaMoInstParameters inst: project.getInstitutions()) {
+                    for (JaCaMoInstParameters inst : project.getInstitutions()) {
                         if (inst.hasWorkspace(wp.getName()) && inst.getRE() != null) {
-                            cartagoCtx.doAction(wid, new Op("setWSPRuleEngine", new Object[] { inst.getRE() } ));
+                            cartagoCtx.doAction(wid, new Op("setWSPRuleEngine", new Object[] { inst.getRE() }));
                         }
                     }
 
                     // create artifacts
-                    for (String aName: wp.getArtifacts().keySet()) {
+                    for (String aName : wp.getArtifacts().keySet()) {
                         String m = null;
                         try {
-                            ClassParameters cp = wp.getArtifacts().get(aName);
-                            m = "artifact "+aName+": "+cp.getClassName()+"("+cp.getParametersStr(",")+") at "+wp.getName();
-                            ArtifactId aid = cartagoCtx.makeArtifact(wid, aName, cp.getClassName(), cp.getTypedParametersArray());
-                            //artIds.put(aName, aid);
-                            logger.info(m+" created.");
-                            if (wp.hasDebug())
-                                EnvironmentInspector.addInGui(wp.getName(), aid);
+                            if (!artifactExists(wp.getName(), aName)) {
+                                ClassParameters cp = wp.getArtifacts().get(aName);
+                                m = "artifact " + aName + ": " + cp.getClassName() + "(" + cp.getParametersStr(",")
+                                        + ") at " + wp.getName();
+                                ArtifactId aid = cartagoCtx.makeArtifact(wid, aName, cp.getClassName(),
+                                        cp.getTypedParametersArray());
+                                // artIds.put(aName, aid);
+                                logger.info(m + " created.");
+                                if (wp.hasDebug())
+                                    EnvironmentInspector.addInGui(wp.getName(), aid);
+                            } else {
+                                logger.info("artifact" + aName + " already exists.");
+
+                            }
                         } catch (CartagoException e) {
-                            logger.log(Level.SEVERE, "error creating "+m,e);
+                            logger.log(Level.SEVERE, "error creating " + m, e);
                         }
                     }
                     if (wp.hasDebug()) {
@@ -68,7 +99,7 @@ public class Cartago extends DefaultPlatformImpl {
                     }
                 }
             } catch (CartagoException e) {
-                logger.log(Level.SEVERE, "error creating environmet, workspace:"+wp.getName(),e);
+                logger.log(Level.SEVERE, "error creating environmet, workspace:" + wp.getName(), e);
             }
         }
     }
@@ -80,5 +111,12 @@ public class Cartago extends DefaultPlatformImpl {
         } catch (CartagoException e) {
             e.printStackTrace();
         }
+    }
+    
+    public boolean artifactExists(String wksName, String artName) throws CartagoException {
+        for (ArtifactId aid : CartagoService.getController(wksName).getCurrentArtifacts()) {
+            if (aid.getName().equals(artName)) return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Cartago class is reading other jcm parameters and creating wks and arts.
Moise class is also reading other jcm to creating its orgs, groups and schemes.
Added a way to get existing platforms in order to use the instance.

There are still open issues: try to follow a standard since moise e cartago classes seem to work differently with sessions. The way to check if an org already exists is bad, it is avoiding exceptions but not dealing with cases of destroyed and recreated jcms.

These changes do not intend to change the way jcm are launched on jacamo startup.