### PR TITLE
Updating doc to np09.zip

### DIFF
--- a/doc/install.adoc
+++ b/doc/install.adoc
@@ -27,24 +27,22 @@ Requirements:
 
 - Java >= 8
 
-Follow the steps below to create a new application (the first time you run them, it takes a while to finish since it downloads JaCaMo first):
+Follow the steps below to create a new application:
 
 Unix::
 +
 ----------------
-curl -s -O http://jacamo.sourceforge.net/nps/np07.zip
-unzip np07.zip
+curl -s -O http://jacamo.sourceforge.net/nps/np09.zip
+unzip np09.zip
 ./gradlew --console=plain
 ----------------
 
 Windows::
-1. Download http://jacamo.sourceforge.net/nps/np07.zip
+1. Download http://jacamo.sourceforge.net/nps/np09.zip
 2. Unzip
 3. Run `gradlew.bat`
 
-
-NOTE: The file `np07.zip` implies the creation of an application based on JaCaMo 0.7.
-You can replace it by `npss.zip` to create a JaCaMo application based on the current snapshot version.
+NOTE: The first time you run them, it takes a while to finish since it downloads JaCaMo first
 
 //https://curl.haxx.se[`curl`] is a program that simply downloads the `np07.zip` file from http://jacamo.sourceforge.net/nps/np07.zip.
 
@@ -53,24 +51,32 @@ You will be asked to enter the identification of the application and then instru
 Example of output:
 ----
 > Task :run
-JaCaMo 0.7 built on Mon Oct 01 20:50:56 BRT 2018
+JaCaMo 0.9 built on Thu Jun 25 21:12:43 BRT 2020
 
-Enter the identification of the new application: bobob
-Creating path /Users/jomi/tmp/bobob
+Enter the identification of the new application: helloworld
+Creating path /Users/jomi/tmp/helloworld
 
 You can run your application with:
-   $ cd /Users/jomi/tmp/bobob
-   $ ./gradlew -q --console=plain
+   cd /Users/jomi/tmp/helloworld
+   ./gradlew -q --console=plain
 
-an eclipse project can be created from menu File/Import,
-option 'Existing Gradle Project'.
+or (if you have JaCaMo scripts installed)
+   jacamo /Users/jomi/tmp/helloworld/helloworld.jcm
+
+an Eclipse project can be created using
+   'Existing Gradle Project' from Eclipse menu File/Import
+
+or
+   ./gradlew eclipse
 ----
 
 If you want to run a JaCaMo application that was not created with a `build.gradle` file, you can download a template from https://raw.githubusercontent.com/jacamo-lang/jacamo/master/src/main/resources/templates/build.gradle[here] and replace
 
-- `<VERSION>` by the required JaCaMo release (e.g. `0.7`)
+- `<VERSION>` by the required JaCaMo release (e.g. `0.9`)
 - `<PROJECT-FILE>` by your .jcm file (e.g. `hello.jcm`).
 
+NOTE: The file `np09.zip` implies the creation of an application based on JaCaMo 0.9.
+You can replace it by `npss.zip` to create a JaCaMo application based on the current snapshot version.
 
 == Shell commands scripts
 

--- a/doc/install.adoc
+++ b/doc/install.adoc
@@ -29,6 +29,8 @@ Requirements:
 
 Follow the steps below to create a new application:
 
+NOTE: The first time you run takes longer since it downloads JaCaMo.
+
 Unix::
 +
 ----------------
@@ -42,7 +44,7 @@ Windows::
 2. Unzip
 3. Run `gradlew.bat`
 
-NOTE: The first time you run them, it takes a while to finish since it downloads JaCaMo first
+TIP: Instead of `np09.zip` you can use `npss.zip` to create a JaCaMo application based on the current snapshot version.
 
 //https://curl.haxx.se[`curl`] is a program that simply downloads the `np07.zip` file from http://jacamo.sourceforge.net/nps/np07.zip.
 
@@ -74,9 +76,6 @@ If you want to run a JaCaMo application that was not created with a `build.gradl
 
 - `<VERSION>` by the required JaCaMo release (e.g. `0.9`)
 - `<PROJECT-FILE>` by your .jcm file (e.g. `hello.jcm`).
-
-NOTE: The file `np09.zip` implies the creation of an application based on JaCaMo 0.9.
-You can replace it by `npss.zip` to create a JaCaMo application based on the current snapshot version.
 
 == Shell commands scripts
 


### PR DESCRIPTION
Due to errors specially on downloading JADE dependency, I suggest moving to a new npXX.zip file. Notice the file np09.zip actually does not exist, but if it follows npss.zip it seems everything will be ok (just notice that npss.zip is pointing to 0.9-SNAPSHOT, I suggest creating a np09.zip pointing to 0.9 stable).

In another issue, personally I think asking to set `JACAMO_HOME` and `JDK_HOME` can be tricky for many users. I suggest explaining how to do it.

Finally, besides using GitHub as a Maven repo for JaCaMo and its subprojects ("https://raw.github.com/jacamo-lang/mvn-repo/master"), it is important to consider moving the npXX.zip files to same/similar repository since Sourceforge is very unstable.