### PR TITLE
Replacing .wait/1 by .at/2

### DIFF
--- a/doc/tutorials/tdd/4_multi_agents/src/test/agt/test_assistant.asl
+++ b/doc/tutorials/tdd/4_multi_agents/src/test/agt/test_assistant.asl
@@ -55,16 +55,26 @@
     .send(clebers_assistant,tell,recipient_agent(mock_room_agent));
     .send(clebers_assistant,achieve,send_preference);
 
-    /* 
-     * Give some time to the room_agent process the information
-     * and mocking a result
-     */
+    .at("now +200 ms", {+!timeout});
+    !eventually;
+    /*
+    Using .at and "eventually" plans to avoid .wait
     .wait(50);
-    //.send(mock_room_agent,askOne,temperature(T),temperature(T));
-    //!assert_equals(24,T);
+    .send(mock_room_agent,askOne,temperature(T),temperature(T));
+    */
+    ?temperature(T);
+    !assert_equals(24,T);
 
     .kill_agent(mock_room_agent);
     .kill_agent(tims_assistant);
     .kill_agent(clebers_assistant);
+.
 
++!timeout <- +timeout.
+
++!eventually: timeout | (temperature(T) & T == 24).
+
++!eventually: not timeout <- 
+	.send(mock_room_agent,askOne,temperature(T));
+	!eventually;
 .


### PR DESCRIPTION
When testing multiple agents we have used .wait, which is not a good approach (it makes the test waits that fixed time, while sometimes a good machine can finish it sooner, and it is also not safe considering that a slow machine may need more time). So, this new version is using .at/2 and "eventually" plans to avoid .wait/1.