### PR TITLE
Ttd eventually

### DIFF
--- a/doc/tutorials/tdd/1_room_agent/build.gradle
+++ b/doc/tutorials/tdd/1_room_agent/build.gradle
@@ -100,6 +100,8 @@ task testJaCaMo {
     description 'runs JaCaMo tests'
     def errorOnTests = false
     outputs.upToDateWhen { false } // disable cache
+    def tempOut = new ByteArrayOutputStream()
+    def tempErr = new ByteArrayOutputStream()
 
     doFirst {
         try {
@@ -114,15 +116,15 @@ task testJaCaMo {
                 }
                 classpath sourceSets.main.runtimeClasspath
 
-                errorOutput = new ByteArrayOutputStream()
-                standardOutput = new ByteArrayOutputStream()
-
+                standardOutput = new org.apache.tools.ant.util.TeeOutputStream(System.out, tempOut);
+                errorOutput = new org.apache.tools.ant.util.TeeOutputStream(System.err, tempErr);
+                
                 ext.stdout = {
-                    return standardOutput.toString()
+                    return tempOut.toString()
                 }
                 ext.errout = {
-                    return errorOutput.toString()
-                }
+                    return tempErr.toString()
+                }                
             }
         } catch (Exception e) {
             errorOnTests = true
@@ -143,7 +145,7 @@ task testJaCaMo {
             line = line.replace("LAUNCHING","${styler['blue']('LAUNCHING')}")
             println line
         }
-
+        
         def err = errout()
         err.splitEachLine('\n') { String line ->
             line = line.replace("TESTING","${styler['yellow']('TESTING')}")
@@ -158,6 +160,7 @@ task testJaCaMo {
             throw new GradleException('JaCaMo tests: ERROR!')
         }
     }
+
 }
 tasks.test.finalizedBy testJaCaMo
 

--- a/doc/tutorials/tdd/2_room_agent_cooling/build.gradle
+++ b/doc/tutorials/tdd/2_room_agent_cooling/build.gradle
@@ -100,6 +100,8 @@ task testJaCaMo {
     description 'runs JaCaMo tests'
     def errorOnTests = false
     outputs.upToDateWhen { false } // disable cache
+    def tempOut = new ByteArrayOutputStream()
+    def tempErr = new ByteArrayOutputStream()
 
     doFirst {
         try {
@@ -114,15 +116,15 @@ task testJaCaMo {
                 }
                 classpath sourceSets.main.runtimeClasspath
 
-                errorOutput = new ByteArrayOutputStream()
-                standardOutput = new ByteArrayOutputStream()
-
+                standardOutput = new org.apache.tools.ant.util.TeeOutputStream(System.out, tempOut);
+                errorOutput = new org.apache.tools.ant.util.TeeOutputStream(System.err, tempErr);
+                
                 ext.stdout = {
-                    return standardOutput.toString()
+                    return tempOut.toString()
                 }
                 ext.errout = {
-                    return errorOutput.toString()
-                }
+                    return tempErr.toString()
+                }                
             }
         } catch (Exception e) {
             errorOnTests = true
@@ -143,7 +145,7 @@ task testJaCaMo {
             line = line.replace("LAUNCHING","${styler['blue']('LAUNCHING')}")
             println line
         }
-
+        
         def err = errout()
         err.splitEachLine('\n') { String line ->
             line = line.replace("TESTING","${styler['yellow']('TESTING')}")

--- a/doc/tutorials/tdd/3_room_agent_with_artifact/build.gradle
+++ b/doc/tutorials/tdd/3_room_agent_with_artifact/build.gradle
@@ -100,6 +100,8 @@ task testJaCaMo {
     description 'runs JaCaMo tests'
     def errorOnTests = false
     outputs.upToDateWhen { false } // disable cache
+    def tempOut = new ByteArrayOutputStream()
+    def tempErr = new ByteArrayOutputStream()
 
     doFirst {
         try {
@@ -114,15 +116,15 @@ task testJaCaMo {
                 }
                 classpath sourceSets.main.runtimeClasspath
 
-                errorOutput = new ByteArrayOutputStream()
-                standardOutput = new ByteArrayOutputStream()
-
+                standardOutput = new org.apache.tools.ant.util.TeeOutputStream(System.out, tempOut);
+                errorOutput = new org.apache.tools.ant.util.TeeOutputStream(System.err, tempErr);
+                
                 ext.stdout = {
-                    return standardOutput.toString()
+                    return tempOut.toString()
                 }
                 ext.errout = {
-                    return errorOutput.toString()
-                }
+                    return tempErr.toString()
+                }                
             }
         } catch (Exception e) {
             errorOnTests = true
@@ -143,7 +145,7 @@ task testJaCaMo {
             line = line.replace("LAUNCHING","${styler['blue']('LAUNCHING')}")
             println line
         }
-
+        
         def err = errout()
         err.splitEachLine('\n') { String line ->
             line = line.replace("TESTING","${styler['yellow']('TESTING')}")

--- a/doc/tutorials/tdd/4_multi_agents/build.gradle
+++ b/doc/tutorials/tdd/4_multi_agents/build.gradle
@@ -100,6 +100,8 @@ task testJaCaMo {
     description 'runs JaCaMo tests'
     def errorOnTests = false
     outputs.upToDateWhen { false } // disable cache
+    def tempOut = new ByteArrayOutputStream()
+    def tempErr = new ByteArrayOutputStream()
 
     doFirst {
         try {
@@ -114,15 +116,15 @@ task testJaCaMo {
                 }
                 classpath sourceSets.main.runtimeClasspath
 
-                errorOutput = new ByteArrayOutputStream()
-                standardOutput = new ByteArrayOutputStream()
-
+                standardOutput = new org.apache.tools.ant.util.TeeOutputStream(System.out, tempOut);
+                errorOutput = new org.apache.tools.ant.util.TeeOutputStream(System.err, tempErr);
+                
                 ext.stdout = {
-                    return standardOutput.toString()
+                    return tempOut.toString()
                 }
                 ext.errout = {
-                    return errorOutput.toString()
-                }
+                    return tempErr.toString()
+                }                
             }
         } catch (Exception e) {
             errorOnTests = true
@@ -143,7 +145,7 @@ task testJaCaMo {
             line = line.replace("LAUNCHING","${styler['blue']('LAUNCHING')}")
             println line
         }
-
+        
         def err = errout()
         err.splitEachLine('\n') { String line ->
             line = line.replace("TESTING","${styler['yellow']('TESTING')}")

--- a/doc/tutorials/tdd/4_multi_agents/src/agt/assistant.asl
+++ b/doc/tutorials/tdd/4_multi_agents/src/agt/assistant.asl
@@ -9,6 +9,12 @@
 //recipient_agent(room_agent).
 //!send_preference.
 
++!send_preference(R)
+    <-
+    -+recipient_agent(R);
+    !send_preference;
+.
+
 +!send_preference:
     preferred_temperature(T) &
     recipient_agent(R)

--- a/doc/tutorials/tdd/4_multi_agents/src/test/agt/test_assistant.asl
+++ b/doc/tutorials/tdd/4_multi_agents/src/test/agt/test_assistant.asl
@@ -49,19 +49,13 @@
     .create_agent(clebers_assistant, "assistant.asl");
 
     .send(tims_assistant,tell,preferred_temperature(23));
-    .send(tims_assistant,tell,recipient_agent(mock_room_agent));
-    .send(tims_assistant,achieve,send_preference);
+    .send(tims_assistant,achieve,send_preference(mock_room_agent));
     .send(clebers_assistant,tell,preferred_temperature(25));
-    .send(clebers_assistant,tell,recipient_agent(mock_room_agent));
-    .send(clebers_assistant,achieve,send_preference);
+    .send(clebers_assistant,achieve,send_preference(mock_room_agent));
 
-    .at("now +200 ms", {+!timeout});
-    !eventually;
-    /*
-    Using .at and "eventually" plans to avoid .wait
-    .wait(50);
-    .send(mock_room_agent,askOne,temperature(T),temperature(T));
-    */
+    !!pollTemperature;
+    .wait(temperature(24), 200, EventTime);
+    .drop_desire(pollTemperature);
     ?temperature(T);
     !assert_equals(24,T);
 
@@ -70,11 +64,9 @@
     .kill_agent(clebers_assistant);
 .
 
-+!timeout <- +timeout.
++!pollTemperature: temperature(24).
 
-+!eventually: timeout | (temperature(T) & T == 24).
-
-+!eventually: not timeout <- 
-	.send(mock_room_agent,askOne,temperature(T));
-	!eventually;
++!pollTemperature  <- 
+    .send(mock_room_agent,askOne,temperature(T));
+    !pollTemperature;
 .


### PR DESCRIPTION
Using a jacamoTest task that prints the report twice. The first printing is not colored, but it happens step by step, showing reports even partially. The second is the colored version. It is not elegant but at least is handling the situation, showing partial reports, which is crucial to understand the situation when a test is crashing.

Regarding the "eventually" approach, the new version is using .wait. In summary, we are replacing the .at by the .wait approach.

```
//Using .at
+!some_plan <-
    .at("now +200 ms", {+!timeout});
    !eventually.
+!timeout <- +timeout.
+!eventually: timeout | condition.
+!eventually: not timeout <-
  //some action
  !eventually.
```


```
//Using .wait
+!some_plan <-
    !!pollVariable;
    .wait(condition, 200, EventTime);
    .drop_desire(pollVariable).
+!pollVariable: condition.
+!pollVariable  <-
    //do some action
    !pollVariable.
```